### PR TITLE
Add environment helper and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ exports/
 imports/
 
 # Configuration files with sensitive data
-config.php
+# The generic config.php shipped with the project only contains helper
+# functions and does not store credentials, so it is safe to track.
 config.local.php
 
 # Media files

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ A robust tool to convert WhatsApp chat exports into Mattermost-compatible format
    ```
 
 > **Important**: The `.env` file contains sensitive information and is automatically ignored by git. Never commit it to version control.
+>
+> The included `src/config.php` helper automatically loads variables from this file when running the converter.
 
 ## 📋 Usage
 

--- a/src/config.php
+++ b/src/config.php
@@ -1,0 +1,53 @@
+<?php
+use Dotenv\Dotenv;
+
+// Load environment variables from .env if present
+$root = dirname(__DIR__);
+if (file_exists($root.'/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+/**
+ * Retrieve environment variable with optional default.
+ */
+function env(string $key, $default = null) {
+    return $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+}
+
+/**
+ * Parse mapping strings of the form "\"Display Name\"=username;..." into an associative array.
+ */
+function parseMappings(string $mappings): array {
+    $result = [];
+    foreach (array_filter(array_map('trim', explode(';', $mappings))) as $pair) {
+        if (preg_match('/^"?(.*?)"?=\"?(.*?)"?$/', $pair, $m)) {
+            $result[$m[1]] = $m[2];
+        }
+    }
+    return $result;
+}
+
+/**
+ * Validate required environment configuration values.
+ * Returns array of error messages if any required variable is missing.
+ */
+function validateEnvironment(): array {
+    $required = [
+        'MATTERMOST_URL',
+        'MATTERMOST_API_TOKEN',
+        'MATTERMOST_TEAM_NAME',
+        'MATTERMOST_CHANNEL_NAME',
+        'WHATSAPP_CHAT_FILE',
+        'IMPORT_ZIP_PATH',
+    ];
+
+    $errors = [];
+    foreach ($required as $var) {
+        if (!env($var)) {
+            $errors[] = "Missing environment variable: $var";
+        }
+    }
+
+    return $errors;
+}
+?>


### PR DESCRIPTION
## Summary
- provide `src/config.php` with helper functions to load `.env`
- allow config.php in repository
- document that config.php automatically loads `.env`

## Testing
- `composer check-syntax`
- `composer test-zip`


------
https://chatgpt.com/codex/tasks/task_e_6883e3fc42e8833190d5ec774b8cb754